### PR TITLE
[Doppins] Upgrade dependency eslint-plugin-react to ^6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "del": "^2.2.0",
     "domready": "^1.0.8",
     "eslint": "^3.1.0",
-    "eslint-plugin-react": "^6.4.1",
+    "eslint-plugin-react": "^6.6.0",
     "estraverse-fb": "^1.3.1 ",
     "fbjs": "^0.7.0",
     "file-loader": "^0.8.4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "del": "^2.2.0",
     "domready": "^1.0.8",
     "eslint": "^3.1.0",
-    "eslint-plugin-react": "^6.7.1",
+    "eslint-plugin-react": "^6.8.0",
     "estraverse-fb": "^1.3.1 ",
     "fbjs": "^0.7.0",
     "file-loader": "^0.8.4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "del": "^2.2.0",
     "domready": "^1.0.8",
     "eslint": "^3.1.0",
-    "eslint-plugin-react": "^6.2.1",
+    "eslint-plugin-react": "^6.2.2",
     "estraverse-fb": "^1.3.1 ",
     "fbjs": "^0.7.0",
     "file-loader": "^0.8.4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "del": "^2.2.0",
     "domready": "^1.0.8",
     "eslint": "^3.1.0",
-    "eslint-plugin-react": "^6.1.2",
+    "eslint-plugin-react": "^6.2.1",
     "estraverse-fb": "^1.3.1 ",
     "fbjs": "^0.7.0",
     "file-loader": "^0.8.4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "del": "^2.2.0",
     "domready": "^1.0.8",
     "eslint": "^3.1.0",
-    "eslint-plugin-react": "^6.2.2",
+    "eslint-plugin-react": "^6.3.0",
     "estraverse-fb": "^1.3.1 ",
     "fbjs": "^0.7.0",
     "file-loader": "^0.8.4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "del": "^2.2.0",
     "domready": "^1.0.8",
     "eslint": "^3.1.0",
-    "eslint-plugin-react": "^6.6.0",
+    "eslint-plugin-react": "^6.7.0",
     "estraverse-fb": "^1.3.1 ",
     "fbjs": "^0.7.0",
     "file-loader": "^0.8.4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "del": "^2.2.0",
     "domready": "^1.0.8",
     "eslint": "^3.1.0",
-    "eslint-plugin-react": "^3.16.1",
+    "eslint-plugin-react": "^6.0.0",
     "estraverse-fb": "^1.3.1 ",
     "fbjs": "^0.7.0",
     "file-loader": "^0.8.4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "del": "^2.2.0",
     "domready": "^1.0.8",
     "eslint": "^3.1.0",
-    "eslint-plugin-react": "^6.7.0",
+    "eslint-plugin-react": "^6.7.1",
     "estraverse-fb": "^1.3.1 ",
     "fbjs": "^0.7.0",
     "file-loader": "^0.8.4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "del": "^2.2.0",
     "domready": "^1.0.8",
     "eslint": "^3.1.0",
-    "eslint-plugin-react": "^6.9.0",
+    "eslint-plugin-react": "^6.10.0",
     "estraverse-fb": "^1.3.1 ",
     "fbjs": "^0.7.0",
     "file-loader": "^0.8.4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "del": "^2.2.0",
     "domready": "^1.0.8",
     "eslint": "^3.1.0",
-    "eslint-plugin-react": "^6.4.0",
+    "eslint-plugin-react": "^6.4.1",
     "estraverse-fb": "^1.3.1 ",
     "fbjs": "^0.7.0",
     "file-loader": "^0.8.4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "del": "^2.2.0",
     "domready": "^1.0.8",
     "eslint": "^3.1.0",
-    "eslint-plugin-react": "^6.8.0",
+    "eslint-plugin-react": "^6.9.0",
     "estraverse-fb": "^1.3.1 ",
     "fbjs": "^0.7.0",
     "file-loader": "^0.8.4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "del": "^2.2.0",
     "domready": "^1.0.8",
     "eslint": "^3.1.0",
-    "eslint-plugin-react": "^6.3.0",
+    "eslint-plugin-react": "^6.4.0",
     "estraverse-fb": "^1.3.1 ",
     "fbjs": "^0.7.0",
     "file-loader": "^0.8.4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "del": "^2.2.0",
     "domready": "^1.0.8",
     "eslint": "^3.1.0",
-    "eslint-plugin-react": "^6.0.0",
+    "eslint-plugin-react": "^6.1.2",
     "estraverse-fb": "^1.3.1 ",
     "fbjs": "^0.7.0",
     "file-loader": "^0.8.4",


### PR DESCRIPTION
Hi!

A new version was just released of `eslint-plugin-react`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded eslint-plugin-react from `^3.16.1` to `^6.0.0`
#### Changelog:
#### Version 6.0.0
### Added
- Add an `all` sharable configuration with all rules enabled ([`#674`](`https://github.com/yannickcr/eslint-plugin-react/issues/674`) `@pfhayes`)
- Add `no-find-dom-node` rule ([`#678`](`https://github.com/yannickcr/eslint-plugin-react/issues/678`))
- Add `shorthandFirst` option to `jsx-sort-props` ([`#391`](`https://github.com/yannickcr/eslint-plugin-react/issues/391`) `@mathieumg`)
- Add `allowDecorators` option to `require-optimization` ([`#669`](`https://github.com/yannickcr/eslint-plugin-react/pull/669`) `@Tom910`)
### Breaking
- Deprecate `require-extension` rule, use the eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import) [`extensions` (`https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/extensions.md`) rule instead. `require-extension` still works but will trigger a warning
- Enable `allow-in-func` mode by default in `no-did-mount-set-state` and `no-did-update-set-state` rules ([`#702`](`https://github.com/yannickcr/eslint-plugin-react/pull/702`) `@lencioni`)
- Enable html tags check by default in `self-closing-comp`
- Remove `pragma` option from `jsx-uses-react`, use the [shared settings](README.md#configuration) to specify a custom pragma ([`#700`](`https://github.com/yannickcr/eslint-plugin-react/pull/700`) `@lencioni`)
- Remove `react` option from `no-deprecated` rule, use the [shared settings](README.md#configuration) to specify the React version ([`#700`](`https://github.com/yannickcr/eslint-plugin-react/pull/700`) `@lencioni`)
- Add `require-render-return` rule to recommended rules
- Remove `no-danger` from recommended rules ([`#636`](`https://github.com/yannickcr/eslint-plugin-react/pull/636`) `@mjackson`)
- Remove `no-did-mount-set-state` and `no-did-update-set-state` from recommended rules ([`#596`](`https://github.com/yannickcr/eslint-plugin-react/issues/596`))
- Remove deprecated `jsx-sort-prop-types` rule, use `sort-prop-types` instead ([`#549`](`https://github.com/yannickcr/eslint-plugin-react/issues/549`) `@lencioni`)
- Rename `no-comment-textnodes` to `jsx-no-comment-textnodes`. `no-comment-textnodes` still works but will trigger a warning ([`#668`](`https://github.com/yannickcr/eslint-plugin-react/issues/668`) `@lencioni`)
- Rename `wrap-multilines` to `jsx-wrap-multilines`. `wrap-multilines` still works but will trigger a warning ([`#668`](`https://github.com/yannickcr/eslint-plugin-react/issues/668`) `@lencioni`)
- Add ESLint as peerDependency ([`#657`](`https://github.com/yannickcr/eslint-plugin-react/pull/657`) `@jokeyrhyme`)
- Add Node.js 0.10 as minimum required version ([`#657`](`https://github.com/yannickcr/eslint-plugin-react/pull/657`) `@jokeyrhyme`)
### Fixed
- Fix `jsx-handler-names` incorrectly flagging `only` ([`#571`](`https://github.com/yannickcr/eslint-plugin-react/issues/571`) `@lencioni`)
- Fix spread props cash in `jsx-no-target-blank` ([`#679`](`https://github.com/yannickcr/eslint-plugin-react/pull/679`) `@randycoulman`)
- Fix `require-optimization` warning on stateless components ([`#687`](`https://github.com/yannickcr/eslint-plugin-react/issues/687`))
- Fix `jsx-uses-vars` that incorrectly marked some variables as used ([`#694`](`https://github.com/yannickcr/eslint-plugin-react/issues/694`) `@lencioni`)
- Fix `no-unknown-property` check on SVG attributes ([`#718`](`https://github.com/yannickcr/eslint-plugin-react/issues/718`))
- Fix `jsx-no-bind` reporting errors on render functions that don't return JSX ([`#663`](`https://github.com/yannickcr/eslint-plugin-react/issues/663`) `@petersendidit`)
- Fix `jsx-closing-bracket-location` autofix when `location` is set to `props-aligned` ([`#684`](`https://github.com/yannickcr/eslint-plugin-react/pull/684`) `@pfhayes`)
- Fix `prop-types` for destructured arguments being assigned to the parent stateless component in some cases ([`#698`](`https://github.com/yannickcr/eslint-plugin-react/issues/698`))
- Fix `prop-types` for JSX return being assigned to the parent function in some cases ([`#504`](`https://github.com/yannickcr/eslint-plugin-react/issues/504`))
- Fix `jsx-curly-spacing` for reporting on JSX content by mistake ([`#671`](`https://github.com/yannickcr/eslint-plugin-react/issues/671`))
- Fix `prop-types` crash when accessing constructor on props ([`#654`](`https://github.com/yannickcr/eslint-plugin-react/issues/654`))
- Fix `jsx-filename-extension` to not check filenames on text input ([`#662`](`https://github.com/yannickcr/eslint-plugin-react/issues/662`) `@ljharb`)
- Fix `jsx-no-comment-textnodes` incorrectly catching urls ([`#664`](`https://github.com/yannickcr/eslint-plugin-react/issues/664`) `@petersendidit`)
### Changed
- Only report `jsx-filename-extension` warning once per file ([`#660`](`https://github.com/yannickcr/eslint-plugin-react/pull/660`) `@mathieumg`)
- Update SVG and DOM attribute list for `no-unknown-property`
- Update rules to use the new ESLint rule format ([`#661`](`https://github.com/yannickcr/eslint-plugin-react/issues/661`) `@petersendidit`)
- Update dependencies
- Documentation improvements ([`#724`](`https://github.com/yannickcr/eslint-plugin-react/pull/724`) `@lencioni`)
- Update Travis CI and AppVeyor CI configurations (`@ljharb`)
#### Version 6.0.0
### Fixed
- Fix `jsx-handler-names` incorrectly flagging `only` ([`#571`](`https://github.com/yannickcr/eslint-plugin-react/issues/571`) `@lencioni`)
- Fix `wrap-multilines` rule ([`#728`](`https://github.com/yannickcr/eslint-plugin-react/pull/728`) `@akozhemiakin`)
#### Version 6.0.0
### Fixed
- Fix spread props crash in `jsx-no-target-blank` ([`#679`](`https://github.com/yannickcr/eslint-plugin-react/pull/679`) `@randycoulman`)
- Fix `require-optimization` warning on stateless components ([`#687`](`https://github.com/yannickcr/eslint-plugin-react/issues/687`))
- Fix `jsx-uses-vars` that incorrectly marked some variables as used ([`#694`](`https://github.com/yannickcr/eslint-plugin-react/issues/694`) `@lencioni`)
- Fix `no-unknown-property` check on SVG attributes ([`#718`](`https://github.com/yannickcr/eslint-plugin-react/issues/718`))
- Fix `all` config to not include deprecated rules ([`#723`](`https://github.com/yannickcr/eslint-plugin-react/pull/723`) `@pfhayes`)
### Breaking
- Deprecate `require-extension rule`, use the eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import) [`extensions` (`https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/extensions.md`) rule instead
- Enable `allow-in-func` mode by default in `no-did-mount-set-state` and `no-did-update-set-state` rules ([`#702`](`https://github.com/yannickcr/eslint-plugin-react/pull/702`) `@lencioni`)
- Enable html tags check by default in `self-closing-comp`
- Remove `pragma` option from `jsx-uses-react`, use the [shared settings](README.md#configuration) to specify a custom pragma ([`#700`](`https://github.com/yannickcr/eslint-plugin-react/pull/700`) `@lencioni`)
- Remove `react` option from `no-deprecated` rule, use the [shared settings](README.md#configuration) to specify the React version ([`#700`](`https://github.com/yannickcr/eslint-plugin-react/pull/700`) `@lencioni`)
- Remove `no-danger` from recommended rules ([`#636`](`https://github.com/yannickcr/eslint-plugin-react/pull/636`) `@mjackson`)
- Remove `no-did-mount-set-state` and no-did-update-set-state from recommended rules ([`#596`](`https://github.com/yannickcr/eslint-plugin-react/issues/596`))
- Add `require-render-return` rule to recommended rules
### Changed
- Update SVG and DOM attribute list for `no-unknown-property`
- Update rules to use the new ESLint rule format ([`#661`](`https://github.com/yannickcr/eslint-plugin-react/issues/661`) `@petersendidit`)
- Documentation improvements ([`#724`](`https://github.com/yannickcr/eslint-plugin-react/pull/724`) `@lencioni`)
#### Version 6.0.0
### Added
- Add an `all` sharable configuration with all rules enabled ([`#674`](`https://github.com/yannickcr/eslint-plugin-react/issues/674`) `@pfhayes`)
- Add `no-find-dom-node` rule ([`#678`](`https://github.com/yannickcr/eslint-plugin-react/issues/678`))
- Add `shorthandFirst` option to `jsx-sort-props` ([`#391`](`https://github.com/yannickcr/eslint-plugin-react/issues/391`) `@mathieumg`)
- Add `allowDecorators` option to `require-optimization` ([`#669`](`https://github.com/yannickcr/eslint-plugin-react/pull/669`) `@Tom910`)
### Fixed
- Fix `jsx-no-bind` reporting errors on render functions that don't return JSX ([`#663`](`https://github.com/yannickcr/eslint-plugin-react/issues/663`) `@petersendidit`)
- Fix `jsx-closing-bracket-location` autofix when `location` is set to `props-aligned` ([`#684`](`https://github.com/yannickcr/eslint-plugin-react/pull/684`) `@pfhayes`)
- Fix `prop-types` for destructured arguments being assigned to the parent stateless component in some cases ([`#698`](`https://github.com/yannickcr/eslint-plugin-react/issues/698`))
- Fix `prop-types` for JSX return being assigned to the parent function in some cases ([`#504`](`https://github.com/yannickcr/eslint-plugin-react/issues/504`))
- Fix `jsx-curly-spacing` for reporting on JSX content by mistake ([`#671`](`https://github.com/yannickcr/eslint-plugin-react/issues/671`))
### Breaking
- Remove deprecated `jsx-sort-prop-types` rule, use `sort-prop-types` instead ([`#549`](`https://github.com/yannickcr/eslint-plugin-react/issues/549`) `@lencioni`)
- Rename `jsx-no-comment-textnodes` to `no-comment-textnodes`. `jsx-no-comment-textnodes` still works but will trigger a warning ([`#668`](`https://github.com/yannickcr/eslint-plugin-react/issues/668`) `@lencioni`)
- Rename `jsx-require-extension` to `require-extension`. `jsx-require-extension` still works but will trigger a warning ([`#668`](`https://github.com/yannickcr/eslint-plugin-react/issues/668`) `@lencioni`)
- Rename `jsx-wrap-multilines` to `wrap-multilines`. `jsx-wrap-multilines` still works but will trigger a warning ([`#668`](`https://github.com/yannickcr/eslint-plugin-react/issues/668`) `@lencioni`)
### Changed
- Update dependencies
- Only report `jsx-filename-extension` warning once per file ([`#660`](`https://github.com/yannickcr/eslint-plugin-react/pull/660`) `@mathieumg`)
#### Version 6.0.0
### Fixed
- Fix `prop-types` crash when accessing constructor on props ([`#654`](`https://github.com/yannickcr/eslint-plugin-react/issues/654`))
- Fix `jsx-filename-extension` to not check filenames on text input ([`#662`](`https://github.com/yannickcr/eslint-plugin-react/issues/662`) `@ljharb`)
- Fix `no-comment-textnodes` incorrectly catching urls ([`#664`](`https://github.com/yannickcr/eslint-plugin-react/issues/664`) `@petersendidit`)
### Breaking
- Add ESLint as peerDependency ([`#657`](`https://github.com/yannickcr/eslint-plugin-react/pull/657`) `@jokeyrhyme`)
- Add Node.js 0.10 as minimum required version ([`#657`](`https://github.com/yannickcr/eslint-plugin-react/pull/657`) `@jokeyrhyme`)
### Changed
- Update dependencies
- Update Travis CI and AppVeyor CI configurations (`@ljharb`)
#### Version 5.2.2
### Fixed
- Fix `jsx-no-bind` crash ([`#641`](`https://github.com/yannickcr/eslint-plugin-react/issues/641`))
#### Version 5.2.1
### Fixed
- Fix `jsx-pascal-case` for namespaced components ([`#637`](`https://github.com/yannickcr/eslint-plugin-react/issues/637`) `@evcohen`)
#### Version 5.2.0
### Added
- Add `require-optimization` rule ([`#240`](`https://github.com/yannickcr/eslint-plugin-react/issues/240`) `@EvNaverniouk`)
- Add `jsx-filename-extension` rule  ([`#495`](`https://github.com/yannickcr/eslint-plugin-react/issues/495`) `@lencioni`)
- Add `no-render-return-value` rule ([`#531`](`https://github.com/yannickcr/eslint-plugin-react/issues/531`) `@iamdustan`)
- Add `no-comment-textnodes` rule ([`#616`](`https://github.com/yannickcr/eslint-plugin-react/pull/616`) `@benvinegar`)
- Add `objectLiterals` option to `jsx-curly-spacing` ([`#388`](`https://github.com/yannickcr/eslint-plugin-react/issues/388`), [`#211`](`https://github.com/yannickcr/eslint-plugin-react/issues/211`) `@casesandberg` `@ljharb`)
- Add option to `self-closing-comp` to check html tags ([`#572`](`https://github.com/yannickcr/eslint-plugin-react/issues/572`) `@gitim`)
- Add `ignore` option to `no-unknown-property` rule ([`#631`](`https://github.com/yannickcr/eslint-plugin-react/pull/631`) `@insin`)
- Add support for ES7 bind operator to `jsx-handler-names` ([`#630`](`https://github.com/yannickcr/eslint-plugin-react/issues/630`))
- Add support for explicit declaration that class extends React.Component ([`#68`](`https://github.com/yannickcr/eslint-plugin-react/issues/68`) `@gausie`)
### Fixed
- Fix `jsx-closing-bracket-location` multiline prop support ([`#493`](`https://github.com/yannickcr/eslint-plugin-react/pull/493`) `@tuures`)
- Fix `prop-types` for props that where not assigned to the right component ([`#591`](`https://github.com/yannickcr/eslint-plugin-react/issues/591`))
- Fix `display-name` when JSON style is used for defining components ([`#590`](`https://github.com/yannickcr/eslint-plugin-react/issues/590`) `@gitim`)
- Fix `jsx-no-bind` for bind detection in render when assigned to a variable ([`#474`](`https://github.com/yannickcr/eslint-plugin-react/issues/474`) `@petersendidit`)
- Fix `jsx-curly-spacing` for spread operator ([`#606`](`https://github.com/yannickcr/eslint-plugin-react/issues/606`) `@gitim`)
- Fix `sort-comp` crash on spread operator ([`#624`](`https://github.com/yannickcr/eslint-plugin-react/issues/624`))
- Fix `prop-types` crash when destructuring props with spread only
### Changed
- Update dependencies
- Add [doctrine](https://github.com/eslint/doctrine) as a dependency ([`#68`](`https://github.com/yannickcr/eslint-plugin-react/issues/68`) `@gausie`)
- Add [jsx-ast-utils](https://github.com/evcohen/jsx-ast-utils) as a dependency ([`#634`](`https://github.com/yannickcr/eslint-plugin-react/pull/634`) `@evcohen`)
- Documentation improvements ([`#594`](`https://github.com/yannickcr/eslint-plugin-react/pull/594`) `@lencioni`, [`#598`](`https://github.com/yannickcr/eslint-plugin-react/pull/598`) `@mLuby`, [`#633`](`https://github.com/yannickcr/eslint-plugin-react/pull/633`) `@appsforartists`)
#### Version 5.1.1
### Fixed
- Fix `require-render-return` crash ([`#589`](`https://github.com/yannickcr/eslint-plugin-react/issues/589`))
#### Version 5.1.0
### Added
- Add `jsx-no-target-blank` rule ([`#582`](`https://github.com/yannickcr/eslint-plugin-react/pull/582`) `@Gasparila`)
- Add `allowAllCaps` and `ignore` options to `jsx-pascal-case` ([`#575`](`https://github.com/yannickcr/eslint-plugin-react/issues/575`))
- Add class properties support to `require-render-return` ([`#564`](`https://github.com/yannickcr/eslint-plugin-react/issues/564`))
### Fixed
- Fix `jsx-closing-bracket-location` fixer ([`#533`](`https://github.com/yannickcr/eslint-plugin-react/issues/533`) `@dtinth`)
- Fix `require-render-return` to only check valid render methods ([`#563`](`https://github.com/yannickcr/eslint-plugin-react/issues/563`))
- Fix detection to allow simple `this` usage in fonctional components ([`#576`](`https://github.com/yannickcr/eslint-plugin-react/issues/576`))
- Fix `forbid-prop-types` crash ([`#579`](`https://github.com/yannickcr/eslint-plugin-react/issues/579`))
- Fix comment handling in `jsx-curly-spacing` ([`#584`](`https://github.com/yannickcr/eslint-plugin-react/pull/584`))
### Changed
- Update dependencies
- Documentation improvements (`@coryhouse`, [`#581`](`https://github.com/yannickcr/eslint-plugin-react/pull/581`) `@scurker`, [`#588`](`https://github.com/yannickcr/eslint-plugin-react/issues/588`))
#### Version 5.0.1
### Fixed
- Fix `require-render-return` to not check stateless functions ([`#550`](`https://github.com/yannickcr/eslint-plugin-react/issues/550`))
#### Version 5.0.0
### Added
- Add `jsx-first-prop-new-line` rule ([`#410`](`https://github.com/yannickcr/eslint-plugin-react/issues/410`) `@jseminck`)
### Breaking
- Update rules for React 15:
  - Add warnings for `LinkedStateMixin`, `ReactPerf.printDOM` and `ReactPerf.getMeasurementsSummaryMap` in `no-deprecated`
  - Allow stateless components to return `null` in `prefer-stateless-function`
  - Remove SVG attributes warnings ([`#490`](`https://github.com/yannickcr/eslint-plugin-react/issues/490`))

If you're still not using React 15 you can keep the old behavior by setting the React version to `0.14` in the [shared settings](README.md#configuration).
### Fixed
- Rewrite `require-render-return` rule ([`#542`](`https://github.com/yannickcr/eslint-plugin-react/issues/542`), [`#543`](`https://github.com/yannickcr/eslint-plugin-react/issues/543`))
- Fix `prefer-stateless-function` crash ([`#544`](`https://github.com/yannickcr/eslint-plugin-react/issues/544`))
- Fix external propTypes handling ([`#545`](`https://github.com/yannickcr/eslint-plugin-react/issues/545`))
- Do not mark inline functions in JSX as components ([`#546`](`https://github.com/yannickcr/eslint-plugin-react/issues/546`))
### Changed
- Update dependencies
- Documentation improvements
#### Version 4.3.0
### Added
- Add `require-render-return` rule ([`#482`](`https://github.com/yannickcr/eslint-plugin-react/issues/482`) `@shmuga`)
- Add auto fix for `jsx-equals-spacing` ([`#506`](`https://github.com/yannickcr/eslint-plugin-react/pull/506`) `@peet`)
- Add auto fix for `jsx-closing-bracket-location` ([`#511`](`https://github.com/yannickcr/eslint-plugin-react/pull/511`) `@KevinGrandon`)
### Fixed
- Fix `prefer-stateless-function` for conditional JSX ([`#516`](`https://github.com/yannickcr/eslint-plugin-react/issues/516`))
- Fix `jsx-pascal-case` to support single letter component names ([`#505`](`https://github.com/yannickcr/eslint-plugin-react/issues/505`) `@dthielman`)
### Changed
- Update dependencies
- Documentation improvements ([`#509`](`https://github.com/yannickcr/eslint-plugin-react/pull/509`) `@coryhouse`, [`#526`](`https://github.com/yannickcr/eslint-plugin-react/pull/526`) `@ahoym`)
#### Version 4.2.3
### Fixed
- Fix class properties retrieval in `prefer-stateless-function` ([`#499`](`https://github.com/yannickcr/eslint-plugin-react/issues/499`))
#### Version 4.2.2
### Fixed
- Rewrite `prefer-stateless-function` rule ([`#491`](`https://github.com/yannickcr/eslint-plugin-react/issues/491`))
- Fix `self-closing-comp` to treat non-breaking spaces as content ([`#496`](`https://github.com/yannickcr/eslint-plugin-react/issues/496`))
- Fix detection for direct props in `prop-types` ([`#497`](`https://github.com/yannickcr/eslint-plugin-react/issues/497`))
- Fix annotated function detection in `prop-types` ([`#498`](`https://github.com/yannickcr/eslint-plugin-react/issues/498`))
- Fix `this` usage in `jsx-no-undef` ([`#489`](`https://github.com/yannickcr/eslint-plugin-react/issues/489`))
### Changed
- Update dependencies
- Add shared setting for React version
#### Version 4.2.1
### Fixed
- Fix `sort-prop-types` crash with spread operator ([`#478`](`https://github.com/yannickcr/eslint-plugin-react/issues/478`))
- Fix stateless components detection when conditionally returning JSX ([`#486`](`https://github.com/yannickcr/eslint-plugin-react/issues/486`))
- Fix case where props were not assigned to the right component ([`#485`](`https://github.com/yannickcr/eslint-plugin-react/issues/485`))
- Fix missing `getChildContext` lifecycle method in `prefer-stateless-function` ([`#492`](`https://github.com/yannickcr/eslint-plugin-react/issues/492`))
#### Version 4.2.0
### Added
- Add support for Flow annotations on stateless components ([`#467`](`https://github.com/yannickcr/eslint-plugin-react/issues/467`))
- Add `prefer-stateless-function` rule ([`#214`](`https://github.com/yannickcr/eslint-plugin-react/issues/214`))
- Add auto fix for `jsx-indent-props` ([`#483`](`https://github.com/yannickcr/eslint-plugin-react/pull/483`) `@shioju`)
### Fixed
- Fix `jsx-no-undef` crash on objects ([`#469`](`https://github.com/yannickcr/eslint-plugin-react/issues/469`))
- Fix propTypes detection when declared before the component ([`#472`](`https://github.com/yannickcr/eslint-plugin-react/issues/472`))
### Changed
- Update dependencies
- Documentation improvements ([`#464`](`https://github.com/yannickcr/eslint-plugin-react/pull/464`) `@alex-tan`, [`#466`](`https://github.com/yannickcr/eslint-plugin-react/pull/466`) `@awong-dev`, [`#470`](`https://github.com/yannickcr/eslint-plugin-react/pull/470`) `@Gpx`; [`#462`](`https://github.com/yannickcr/eslint-plugin-react/pull/462`) `@thaggie`)
#### Version 4.1.0
### Added
- Add component detection for class expressions
- Add displayName detection for class expressions in `display-name` ([`#419`](`https://github.com/yannickcr/eslint-plugin-react/issues/419`))
### Fixed
- Fix used props detection in components for which we are not confident in `prop-types` ([`#420`](`https://github.com/yannickcr/eslint-plugin-react/issues/420`))
- Fix false positive in `jsx-key` ([`#456`](`https://github.com/yannickcr/eslint-plugin-react/pull/456`) `@jkimbo`)
### Changed
- Documentation improvements ([`#457`](`https://github.com/yannickcr/eslint-plugin-react/pull/457`) `@wyze`)
#### Version 4.0.0
### Added
- Add `jsx-space-before-closing` rule ([`#244`](`https://github.com/yannickcr/eslint-plugin-react/issues/244`) `@ryym`)
- Add support for destructing in function signatures to `prop-types` ([`#354`](`https://github.com/yannickcr/eslint-plugin-react/issues/354`) `@lencioni`)
### Breaking
- Add support for static methods to `sort-comp`. Static methods must now be declared first, see [rule documentation](docs/rules/sort-comp.md) ([`#128`](`https://github.com/yannickcr/eslint-plugin-react/issues/128`) `@lencioni`)
- Add shareable config in place of default configuration. `jsx-uses-vars` is not enabled by default anymore, see [documentation](README.md#recommended-configuration) ([`#192`](`https://github.com/yannickcr/eslint-plugin-react/issues/192`))
- Rename `jsx-sort-prop-types` to `sort-prop-types`. `jsx-sort-prop-types` still works but will trigger a warning ([`#87`](`https://github.com/yannickcr/eslint-plugin-react/issues/87`) `@lencioni`)
- Remove deprecated `jsx-quotes` rule ([`#433`](`https://github.com/yannickcr/eslint-plugin-react/pull/433`) `@lencioni`)
- `display-name` now accept the transpiler name by default. You can use the `ignoreTranspilerName` option to get the old behavior, see [rule documentation](docs/rules/display-name.md#ignoretranspilername) ([`#440`](`https://github.com/yannickcr/eslint-plugin-react/pull/440`) `@lencioni`)
### Fixed
- Only ignore lowercase JSXIdentifier in `jsx-no-undef` ([`#435`](`https://github.com/yannickcr/eslint-plugin-react/issues/435`))
- Fix `jsx-handler-names` regex ([`#425`](`https://github.com/yannickcr/eslint-plugin-react/issues/425`))
- Fix destructured props detection in `prop-types` ([`#443`](`https://github.com/yannickcr/eslint-plugin-react/issues/443`))
### Changed
- Update dependencies ([`#426`](`https://github.com/yannickcr/eslint-plugin-react/pull/426`) `@quentin-`)
- Documentation improvements ([`#414`](`https://github.com/yannickcr/eslint-plugin-react/pull/414`) `@vkrol`, [`#370`](`https://github.com/yannickcr/eslint-plugin-react/pull/370`) `@tmcw`, [`#441`](`https://github.com/yannickcr/eslint-plugin-react/pull/441`) [`#429`](`https://github.com/yannickcr/eslint-plugin-react/pull/429`) `@lencioni`, [`#432`](`https://github.com/yannickcr/eslint-plugin-react/pull/432`) `@Niler851`, [`#438`](`https://github.com/yannickcr/eslint-plugin-react/pull/438`) `@jmann6`)
#### Version 4.0.0
### Fixed
- Fix `jsx-handler-names` regex ([`#425`](`https://github.com/yannickcr/eslint-plugin-react/issues/425`))
- Fix destructured props detection in `prop-types` ([`#443`](`https://github.com/yannickcr/eslint-plugin-react/issues/443`))
#### Version 4.0.0
### Added
- Add `jsx-space-before-closing` rule ([`#244`](`https://github.com/yannickcr/eslint-plugin-react/issues/244`) `@ryym`)
- Add support for destructing in function signatures to `prop-types` ([`#354`](`https://github.com/yannickcr/eslint-plugin-react/issues/354`) `@lencioni`)
### Breaking
- Add support for static methods to `sort-comp`. Static methods must now be declared first, see [rule documentation](docs/rules/sort-comp.md) ([`#128`](`https://github.com/yannickcr/eslint-plugin-react/issues/128`) `@lencioni`)
- Add shareable config in place of default configuration. `jsx-uses-vars` is not enabled by default anymore, see [documentation](README.md#recommended-configuration) ([`#192`](`https://github.com/yannickcr/eslint-plugin-react/issues/192`))
- Rename `jsx-sort-prop-types` to `sort-prop-types`. `jsx-sort-prop-types` still works but will trigger a warning ([`#87`](`https://github.com/yannickcr/eslint-plugin-react/issues/87`) `@lencioni`)
- Remove deprecated `jsx-quotes` rule ([`#433`](`https://github.com/yannickcr/eslint-plugin-react/pull/433`) `@lencioni`)
- `display-name` now accept the transpiler name by default. You can use the `ignoreTranspilerName` option to get the old behavior, see [rule documentation](docs/rules/display-name.md#ignoretranspilername) ([`#440`](`https://github.com/yannickcr/eslint-plugin-react/pull/440`) `@lencioni`)
### Fixed
- Only ignore lowercase JSXIdentifier in `jsx-no-undef` ([`#435`](`https://github.com/yannickcr/eslint-plugin-react/issues/435`))
### Changed
- Update dependencies ([`#426`](`https://github.com/yannickcr/eslint-plugin-react/pull/426`) `@quentin-`)
- Documentation improvements ([`#414`](`https://github.com/yannickcr/eslint-plugin-react/pull/414`) `@vkrol`, [`#370`](`https://github.com/yannickcr/eslint-plugin-react/pull/370`) `@tmcw`, [`#441`](`https://github.com/yannickcr/eslint-plugin-react/pull/441`) [`#429`](`https://github.com/yannickcr/eslint-plugin-react/pull/429`) `@lencioni`, [`#432`](`https://github.com/yannickcr/eslint-plugin-react/pull/432`) `@Niler851`, [`#438`](`https://github.com/yannickcr/eslint-plugin-react/pull/438`) `@jmann6`)
